### PR TITLE
feat: adding the ability to remove manual assignment

### DIFF
--- a/src/components/AdminCampaignList/CampaignTable.jsx
+++ b/src/components/AdminCampaignList/CampaignTable.jsx
@@ -14,6 +14,7 @@ import SpeakerNotesIcon from "@material-ui/icons/SpeakerNotes";
 import IconButton from "@material-ui/core/IconButton";
 import CircularProgress from "@material-ui/core/CircularProgress";
 import Link from "@material-ui/core/Link";
+import identity from "lodash/identity";
 
 const inlineStyles = {
   campaignInfo: {
@@ -220,7 +221,7 @@ export class CampaignTable extends React.Component {
           }
         }
       },
-      {
+      !global.HIDE_MANUAL_ASSIGNMENT && {
         key: "unassigned",
         name: "unassigned",
         label: "Unassigned",
@@ -275,7 +276,7 @@ export class CampaignTable extends React.Component {
         }
       },
       ...extraRows
-    ];
+    ].filter(identity);
   }
 
   getSelectedRowIndexes = () => {

--- a/src/components/CampaignDynamicAssignmentForm.jsx
+++ b/src/components/CampaignDynamicAssignmentForm.jsx
@@ -59,20 +59,22 @@ class CampaignDynamicAssignmentForm extends React.Component {
       .map(p => ({ id: p, name: p }));
     return (
       <div>
-        <FormControlLabel
-          control={
-            <Switch
-              color="primary"
-              checked={useDynamicAssignment || false}
-              onChange={(toggler, val) => {
-                console.log(toggler, val);
-                this.toggleChange("useDynamicAssignment", val);
-              }}
-            />
-          }
-          label="Allow texters with a link to join and start texting when the campaign is started?"
-          labelPlacement="start"
-        />
+        {!global.HIDE_MANUAL_ASSIGNMENT && (
+          <FormControlLabel
+            control={
+              <Switch
+                color="primary"
+                checked={useDynamicAssignment || false}
+                onChange={(toggler, val) => {
+                  console.log(toggler, val);
+                  this.toggleChange("useDynamicAssignment", val);
+                }}
+              />
+            }
+            label="Allow texters with a link to join and start texting when the campaign is started?"
+            labelPlacement="start"
+          />
+        )}
         <GSForm
           schema={this.formSchema}
           value={this.state}
@@ -92,10 +94,12 @@ class CampaignDynamicAssignmentForm extends React.Component {
                     "Please save the campaign and reload the page to get the join link to share with texters."
                   )}
                 </li>
-                <li>
-                  You can turn off dynamic assignment after starting a campaign
-                  to disallow more new texters to join
-                </li>
+                {!global.HIDE_MANUAL_ASSIGNMENT && (
+                  <li>
+                    You can turn off dynamic assignment after starting a
+                    campaign to disallow more new texters to join
+                  </li>
+                )}
               </ul>
               <p>
                 Batch sizes are how many texts someone should send before they

--- a/src/containers/AdminCampaignEdit.jsx
+++ b/src/containers/AdminCampaignEdit.jsx
@@ -42,6 +42,7 @@ import CampaignTextingHoursForm from "../components/CampaignTextingHoursForm";
 import { styles } from "./AdminCampaignStats";
 import AdminScriptImport from "../containers/AdminScriptImport";
 import { makeTree } from "../lib";
+import identity from "lodash/identity";
 
 const campaignInfoFragment = `
   id
@@ -448,7 +449,7 @@ export class AdminCampaignEditBase extends React.Component {
             : {})
         }
       },
-      {
+      !global.HIDE_MANUAL_ASSIGNMENT && {
         title: "Texters",
         content: CampaignTextersForm,
         keys: ["texters", "contactsCount"],
@@ -664,7 +665,7 @@ export class AdminCampaignEditBase extends React.Component {
         doNotSaveAfterSubmit: true
       });
     }
-    return finalSections;
+    return finalSections.filter(identity);
   }
 
   sectionSaveStatus(section) {

--- a/src/containers/AdminCampaignList.jsx
+++ b/src/containers/AdminCampaignList.jsx
@@ -75,7 +75,8 @@ export class AdminCampaignList extends React.Component {
       interactionSteps: {
         script: "",
         id: "new"
-      }
+      },
+      useDynamicAssignment: global.HIDE_MANUAL_ASSIGNMENT
     });
 
     if (newCampaign.errors) {

--- a/src/server/middleware/render-index.js
+++ b/src/server/middleware/render-index.js
@@ -134,6 +134,13 @@ export default function renderIndex(html, css, assetMap) {
       window.ASSIGNMENT_CONTACTS_SIDEBAR=${getConfig(
         "ASSIGNMENT_CONTACTS_SIDEBAR"
       )}
+      window.HIDE_MANUAL_ASSIGNMENT=${getConfig(
+        "HIDE_MANUAL_ASSIGNMENT",
+        null,
+        {
+          truthy: 1
+        }
+      ) || false};
     </script>
     <script src="${assetMap["bundle.js"]}"></script>
   </body>


### PR DESCRIPTION
This is a follow up to the delegated auth piece, as users who are authenticated on a separate app will use dynamic assignment exclusively.

